### PR TITLE
Enable automatic Windows builds with AppVeyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Q2VKPT [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/cschied/q2vkpt?branch=master&svg=true)](https://ci.appveyor.com/project/cschied/q2vkpt)
+
 Welcome to Q2VKPT, a Quake II engine with real-time path tracing.  This client
 implements fully dynamic illumination without precomputation supporting area
 light sources, reflections, soft shadows, and indirect illumination. This
@@ -5,9 +7,8 @@ client is a port of our real-time path tracer vkpt and is based on the Quake II
 engine Q2PRO.
 
 This client requires a high-end GPU supporting the Vulkan extension
-VK_NV_ray_tracing.
+`VK_NV_ray_tracing`.
 
 Please refer to our project page for more details.
 
 Project homepage: http://brechpunkt.de/q2vkpt
-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,15 @@
 image: Visual Studio 2017
 configuration: Release
 
-before_build:
-- cmd: |-
-    cd %APPVEYOR_BUILD_FOLDER%
-    mkdir cmake_build
-    cd cmake_build
-    cmake --version
+install:
+  ## Prepare .sln with cmake
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - mkdir cmake_build
+  - cd cmake_build
+  - cmake --version
+  - cmake c:\projects\q2vkpt
 
-build_script: cmake c:\projects\q2vkpt
+build_script: msbuild "C:\projects\mozjpeg\cmake_build\q2vkpt.sln"
 
 artifacts:
- - path: cmake_build\**\*.zip
+ - path: cmake_build\Release\**\*.*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ install:
   - cmake --version
   - cmake c:\projects\q2vkpt
 
-build_script: msbuild "C:\projects\q2vkpt\cmake_build\q2vkpt.sln"
+build_script: msbuild "C:\projects\q2vkpt\cmake_build\quake2-pt.sln"
 
 artifacts:
  - path: cmake_build\Release\**\*.*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,12 +7,8 @@ before_build:
     mkdir cmake_build
     cd cmake_build
     cmake --version
-build_script:
-  cmake c:\projects\q2vkpt
- 
+
+build_script: cmake c:\projects\q2vkpt
+
 artifacts:
- - path: cmake_build\Release\**\*.*
- - path: cmake_build\Release\*.*
- - path: cmake_build\**\*.exe
- - path: cmake_build\**\*.lib
- 
+ - path: cmake_build\**\*.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ install:
   - cmake --version
   - cmake c:\projects\q2vkpt
 
-build_script: msbuild "C:\projects\mozjpeg\cmake_build\q2vkpt.sln"
+build_script: msbuild "C:\projects\q2vkpt\cmake_build\q2vkpt.sln"
 
 artifacts:
  - path: cmake_build\Release\**\*.*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+image: Visual Studio 2017
+configuration: Release
+
+before_build:
+- cmd: |-
+    cd %APPVEYOR_BUILD_FOLDER%
+    mkdir cmake_build
+    cd cmake_build
+    cmake --version
+build_script:
+  cmake c:\projects\q2vkpt
+ 
+artifacts:
+ - path: cmake_build\Release\**\*.*
+ - path: cmake_build\Release\*.*
+ - path: cmake_build\**\*.exe
+ - path: cmake_build\**\*.lib
+ 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@ image: Visual Studio 2017
 configuration: Release
 
 install:
+  ## Clone git submodules
+   - git submodule update --init --recursive
   ## Prepare .sln with cmake
   - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir cmake_build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ configuration: Release
 
 install:
   ## Clone git submodules
-   - git submodule update --init --recursive
+  - git submodule update --init --recursive
   ## Prepare .sln with cmake
   - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir cmake_build


### PR DESCRIPTION
Add continuous integration with AppVeyor, which enables automatic builds of q2vkpt for x86-64 Windows. Example can be found [here](https://ci.appveyor.com/project/EwoutH/q2vkpt).

AppVeyor only needs to be [enabled](https://github.com/marketplace/appveyor) on the GitHub Marketplace.