### PR TITLE
Fix an incorrect operator

### DIFF
--- a/src/refresh/vkpt/shader/asvgf_atrous.comp
+++ b/src/refresh/vkpt/shader/asvgf_atrous.comp
@@ -133,9 +133,7 @@ main()
 	if(any(greaterThanEqual(ipos, ivec2(global_ubo.width, global_ubo.height))))
 		return;
 
-#define tex_depth_normal ((global_ubo.current_frame_idx % 1) > 0 ?  IMG_PT_DEPTH_NORMAL_A : IMG_PT_DEPTH_NORMAL_B)
-
-	const int frame_idx = global_ubo.current_frame_idx % 1;
+	const int frame_idx = global_ubo.current_frame_idx & 1;
 
 	vec4 filtered = vec4(0);
 	switch(push.iteration) {


### PR DESCRIPTION
Also remove an unused define.

I haven't yet set up my local copy such that I can compile it, and I don't have a compatible GPU to test this in any case. Someone please verify that this is correct.

EDIT: Compiles fine. I got help from someone with a compatible GPU for testing and it doesn't make much difference, but it does appear to reduce a light bleeding issue on object edges in motion.